### PR TITLE
Add .gitignore for node_modules and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Node modules
+node_modules/
+
+# Temporary files
+*.log
+*.tmp
+*~
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Output directories
+build/
+dist/
+.tmp/
+tmp/
+.cache/
+


### PR DESCRIPTION
## Summary
- create `.gitignore` to exclude `node_modules/` and common temporary files

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6841a52052848332b12852b260dbfbef