### PR TITLE
Update README to document GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,24 @@ To build the project locally:
    npm run build
    ```
 
+3. Serve the files locally (required for module scripts):
+   ```bash
+   npx http-server .
+   ```
+
+   Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+Opening `index.html` directly with the `file://` protocol may result in a blank
+page because browsers restrict module loading from local files.
+
 The `build` script uses [esbuild](https://esbuild.github.io/) to bundle `App.js` while leaving `react` and `react-dom` as external dependencies.
+
+## Deploying to GitHub Pages
+
+1. Build the project and commit the `bundle.js`, `index.html`, and `CNAME` files.
+2. Push the repository to GitHub.
+3. In the repository Settings > Pages, choose the `main` branch (root) as the source and save.
+4. Add `solheim.online` as the custom domain in the same Pages settings. GitHub will automatically create the `CNAME` file if it does not exist.
+5. Update your DNS provider to point the domain to GitHub Pages by adding A records for `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, and `185.199.111.153`.
+
+After DNS changes propagate, visiting [https://solheim.online](https://solheim.online) should load the site.


### PR DESCRIPTION
## Summary
- add instructions for deploying to GitHub Pages and setting `solheim.online`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841af41543c8332b277f27f12cf2ce6